### PR TITLE
Fix config_align.h to use <>

### DIFF
--- a/config_align.h
+++ b/config_align.h
@@ -22,10 +22,10 @@
 #ifndef CRYPTOPP_CONFIG_ALIGN_H
 #define CRYPTOPP_CONFIG_ALIGN_H
 
-#include "config_asm.h"  // CRYPTOPP_DISABLE_ASM
-#include "config_cpu.h"  // X86, X32, X64, ARM32, ARM64, etc
-#include "config_cxx.h"  // CRYPTOPP_CXX11_ALIGNAS
-#include "config_ver.h"  // Compiler versions
+#include <config_asm.h>  // CRYPTOPP_DISABLE_ASM
+#include <config_cpu.h>  // X86, X32, X64, ARM32, ARM64, etc
+#include <config_cxx.h>  // CRYPTOPP_CXX11_ALIGNAS
+#include <config_ver.h>  // Compiler versions
 
 // Nearly all Intel's and AMD's have SSE. Enable it independent of SSE ASM and intrinsics.
 // ARM NEON and ARMv8 ASIMD only need natural alignment of an element in the vector.


### PR DESCRIPTION
`#include` with quotes `""` picks local `config_*.h` instead of Android ABI specific, generated out of the source tree